### PR TITLE
Work around undefined exports, fixes #1

### DIFF
--- a/lib/which-key-view.js
+++ b/lib/which-key-view.js
@@ -5,11 +5,13 @@ import etch from 'etch';
 import Type from './type';
 import Keys from './keys';
 
-export const { Partial, Failed, Nothing } = new Type({
+const { Partial, Failed, Nothing } = new Type({
   Partial: ['keystrokes', 'bindings'],
   Failed: ['keystrokes'],
   Nothing: [],
 });
+
+export { Partial, Failed, Nothing };
 
 export default class WhichKeyView {
 


### PR DESCRIPTION
I suspect this was caused by atom/atom#13823, but the `export const {Partial}` syntax should still work.