### PR TITLE
add fetaure - ignored list of keys

### DIFF
--- a/lib/which-key-view.js
+++ b/lib/which-key-view.js
@@ -98,8 +98,8 @@ export default class WhichKeyView {
   _groupBindings(keystrokes = [], bindings = []) {
     const getGroup = command => (command.match(/^([^:\s]+)/i) || [])[1];
     const getCommand = command => (command.match(/([^:\s]+)$/i) || [])[1];
-
     const { prefixes, groups } = bindings
+      .filter(this._removeIgnoredKeys.bind(this))
       .reduce(({ prefixes, groups }, b) => {
         const prefix = b.keystrokeArray[keystrokes.length];
         const group = getGroup(b.command);
@@ -136,6 +136,10 @@ export default class WhichKeyView {
       }));
   }
 
+  _removeIgnoredKeys(binding) {
+    return !this.ignoredKeys.includes(binding.keystrokes);
+  }
+
   get keystrokesFormat() {
     return atom.config.get('which-key.keystrokesFormat');
   }
@@ -146,6 +150,10 @@ export default class WhichKeyView {
 
   get useMetaForAlt() {
     return atom.config.get('which-key.useMetaForAlt');
+  }
+
+  get ignoredKeys() {
+    return atom.config.get('which-key.ignoredKeys') || [];
   }
 
   get _style() {


### PR DESCRIPTION
This feature allows the user to define a list of keybindings(`init.coffee`) that should be ignored by the plugin.

`init.coffee`
```coffee
# This key will never appear on the panel
atom.config.set('which-key.ignoredKeys', ['ctrl-space p 9']) 
```